### PR TITLE
Add profile picture generator

### DIFF
--- a/components/ProfilePicture.js
+++ b/components/ProfilePicture.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import Image from 'next/image';
+
+export default function ProfilePicture() {
+  const [style, setStyle] = useState('');
+  const [imageUrl, setImageUrl] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const generateImage = async () => {
+    if (!style.trim()) return;
+    setLoading(true);
+    setImageUrl(null);
+    try {
+      const res = await fetch('/api/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: style }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      setImageUrl(data.url);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ textAlign: 'center', mt: 4 }}>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        Generate Profile Picture
+      </Typography>
+      <TextField
+        label="Hairstyle"
+        variant="outlined"
+        value={style}
+        onChange={(e) => setStyle(e.target.value)}
+        sx={{ width: '100%', maxWidth: 360 }}
+      />
+      <Button
+        variant="contained"
+        onClick={generateImage}
+        sx={{ mt: 2 }}
+        disabled={loading}
+      >
+        Generate
+      </Button>
+      <Box sx={{ mt: 4, minHeight: 256 }}>
+        {loading && <CircularProgress />}
+        {imageUrl && (
+          <Box sx={{ position: 'relative', width: 256, height: 256, mx: 'auto' }}>
+            <Image src={imageUrl} alt="Profile" fill style={{ objectFit: 'cover' }} />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "module",
   "bugs": {
     "url": "https://github.com/Juangunner4/dogwifhair/issues"
   },

--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -1,0 +1,39 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { prompt } = req.body || {};
+  if (!prompt) {
+    res.status(400).json({ error: 'Missing prompt' });
+    return;
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        prompt: `profile picture with ${prompt}`,
+        n: 1,
+        size: '256x256',
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      res.status(response.status).json({ error });
+      return;
+    }
+
+    const data = await response.json();
+    const url = data.data && data.data[0] ? data.data[0].url : null;
+    res.status(200).json({ url });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Box from '@mui/material/Box'
 import NavBar from '../components/NavBar'
 import HeroSection from '../components/HeroSection'
+import ProfilePicture from '../components/ProfilePicture'
 import ContractSection from '../components/ContractSection'
 import Footer from '../components/Footer'
 
@@ -17,7 +18,7 @@ export default function Home() {
         <HeroSection />
       </Box>
       <ContractSection />
+  <ProfilePicture />
       <Footer />
     </>
-  )
-}
+  )}


### PR DESCRIPTION
## Summary
- restore `next.config.js` so it is kept in the repo
- remove `"type": "module"` from `package.json` to keep the config CJS compatible
- keep ProfilePicture component and API route for image generation

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ee1ba3e3c832a9ebb5d8bfc2da5dc