### PR TITLE
Fix Next.js static export build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,11 +21,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build & export static site
-        run: |
-          npm ci
-          npm run build    
-          npm run export    
+      - name: Build static site
+        run: npm run build
 
       - name: Deploy via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.0

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // enable static HTML export  output: 'export',
+  // enable static HTML export
+  output: 'export',
+  images: {
+    unoptimized: true,
+  },
 };
 
-export default nextConfig;
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- fix `next.config.js` to use CommonJS
- disable image optimization for static export
- simplify GH Actions workflow to run build only

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ee64878b0832a8cc355f980b55e75