### PR TITLE
Configure OpenAI key for build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Create env file
+        run: echo "NEXT_PUBLIC_OPENAI_API_KEY=${{ secrets.NEXT_PUBLIC_OPENAI_API_KEY }}" > .env.local
+
       - name: Build static site
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ To generate the static site use:
 ```bash
 npm run build
 ```
+
+## Deployment
+
+The GitHub Actions workflow deploys the static site to HostGator. Ensure that `NEXT_PUBLIC_OPENAI_API_KEY` is added as a repository secret so the build can access the OpenAI API during deployment.


### PR DESCRIPTION
## Summary
- create `.env.local` in the workflow from the `NEXT_PUBLIC_OPENAI_API_KEY` secret
- document the deployment secret in the README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686f08f89da4832aaad42eae544d51d6