### PR TITLE
Fix localStorage quota issue

### DIFF
--- a/components/ProfilePicture.js
+++ b/components/ProfilePicture.js
@@ -81,10 +81,7 @@ export default function ProfilePicture() {
       const newCount = dailyCount + 1
       setDailyCount(newCount)
       localStorage.setItem('ppCount', newCount.toString())
-      // Save generated image to gallery
-      const gallery = JSON.parse(localStorage.getItem('galleryImages') || '[]')
-      gallery.unshift(url)
-      localStorage.setItem('galleryImages', JSON.stringify(gallery))
+      // Notify gallery to reload from the server
       window.dispatchEvent(new Event('gallery.update'))
     } catch (err) {
       console.error(err)


### PR DESCRIPTION
## Summary
- remove galleryImages usage to avoid hitting the localStorage quota

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877e5bf0a84832a8caf6ee03416f589